### PR TITLE
Android RTS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ serial.open(opts, function success(), function error());
 - stopBits: defaults to 1
 - parity: defaults to 0
 - dtr: defaults to false (it may be needed to be true for some arduino)
+- rts: defaults to false (it may be needed to be true for some modules, including the monkeyboard dab module)
 - sleepOnPause: defaults to true. If false, the the OTG port will remain open when the app goes to the background (or the screen turns off). Otherwise, the port with automatically close, and resume once the app is brought back to foreground.
 
 You're now able to read and write:

--- a/src/android/fr/drangies/cordova/serial/Serial.java
+++ b/src/android/fr/drangies/cordova/serial/Serial.java
@@ -67,6 +67,7 @@ public class Serial extends CordovaPlugin {
 	private int stopBits;
 	private int parity;
 	private boolean setDTR;
+    private boolean setRTS;
 	private boolean sleepOnPause;
 	
 	// callback that will be used to send back data to the cordova app
@@ -234,12 +235,14 @@ public class Serial extends CordovaPlugin {
 						stopBits = opts.has("stopBits") ? opts.getInt("stopBits") : UsbSerialPort.STOPBITS_1;
 						parity = opts.has("parity") ? opts.getInt("parity") : UsbSerialPort.PARITY_NONE;
 						setDTR = opts.has("dtr") && opts.getBoolean("dtr");
+                        setRTS = opts.has("rts") && opts.getBoolean("rts");
 						// Sleep On Pause defaults to true
 						sleepOnPause = opts.has("sleepOnPause") ? opts.getBoolean("sleepOnPause") : true;
 
 						port.open(connection);
 						port.setParameters(baudRate, dataBits, stopBits, parity);
 						if (setDTR) port.setDTR(true);
+                        if (setRTS) port.setRTS(true);
 					}
 					catch (IOException  e) {
 						// deal with error
@@ -507,6 +510,7 @@ public class Serial extends CordovaPlugin {
 						port.open(connection);
 						port.setParameters(baudRate, dataBits, stopBits, parity);
 						if (setDTR) port.setDTR(true);
+                        if (setRTS) port.setRTS(true);
 					}
 					catch (IOException  e) {
 						// deal with error

--- a/src/android/fr/drangies/cordova/serial/Serial.java
+++ b/src/android/fr/drangies/cordova/serial/Serial.java
@@ -67,7 +67,7 @@ public class Serial extends CordovaPlugin {
 	private int stopBits;
 	private int parity;
 	private boolean setDTR;
-    private boolean setRTS;
+	private boolean setRTS;
 	private boolean sleepOnPause;
 	
 	// callback that will be used to send back data to the cordova app

--- a/src/android/fr/drangies/cordova/serial/Serial.java
+++ b/src/android/fr/drangies/cordova/serial/Serial.java
@@ -235,14 +235,14 @@ public class Serial extends CordovaPlugin {
 						stopBits = opts.has("stopBits") ? opts.getInt("stopBits") : UsbSerialPort.STOPBITS_1;
 						parity = opts.has("parity") ? opts.getInt("parity") : UsbSerialPort.PARITY_NONE;
 						setDTR = opts.has("dtr") && opts.getBoolean("dtr");
-                        setRTS = opts.has("rts") && opts.getBoolean("rts");
+						setRTS = opts.has("rts") && opts.getBoolean("rts");
 						// Sleep On Pause defaults to true
 						sleepOnPause = opts.has("sleepOnPause") ? opts.getBoolean("sleepOnPause") : true;
 
 						port.open(connection);
 						port.setParameters(baudRate, dataBits, stopBits, parity);
 						if (setDTR) port.setDTR(true);
-                        if (setRTS) port.setRTS(true);
+						if (setRTS) port.setRTS(true);
 					}
 					catch (IOException  e) {
 						// deal with error
@@ -510,7 +510,7 @@ public class Serial extends CordovaPlugin {
 						port.open(connection);
 						port.setParameters(baudRate, dataBits, stopBits, parity);
 						if (setDTR) port.setDTR(true);
-                        if (setRTS) port.setRTS(true);
+						if (setRTS) port.setRTS(true);
 					}
 					catch (IOException  e) {
 						// deal with error


### PR DESCRIPTION
Added RTS support option to support the monkeyboard DAB development board.

[http://www.monkeyboard.org/products/85-developmentboard/85-dab-dab-fm-digital-radio-development-board-pro](http://www.monkeyboard.org/products/85-developmentboard/85-dab-dab-fm-digital-radio-development-board-pro)

This can be enabled just like DTR:
` serial.requestPermission({
            vid: '04D8',
            pid: '000A',
            dtr: false,
            rts: true,
            driver: 'CdcAcmSerialDriver' // or any other
        }function(successMessage) {
})`

