### PR TITLE
Overload write method to accept ArrayBuffer data

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You're now able to read and write:
 serial.write(data, function success(), function error());
 serial.read(function success(buffer), function error());
 ```
-`data` is the string representation to be written to the serial port.
+`data` is an ArrayBuffer or the string representation to be written to the serial port.
 `buffer` is a JavaScript ArrayBuffer containing the data that was just read.
 
 Apart from using `serial.write`, you can also use `serial.writeHex` to have an easy way to work with **RS232 protocol** driven hardware from your javascript by using **hex-strings**.

--- a/www/serial.js
+++ b/www/serial.js
@@ -23,6 +23,9 @@ var serial = {
         );
     },
     write: function(data, successCallback, errorCallback) {
+        if (data instanceof ArrayBuffer) {
+            data = String.fromCharCode.apply(null, new Uint8Array(data));
+        }
         cordova.exec(
             successCallback,
             errorCallback,


### PR DESCRIPTION
I've always been a little confused about `Serial.read()` returning `ArrayBuffer`, but `Serial.write()` requiring a string argument. Sure, there's the `Serial.writeHex()` method, but to me it's a little odd that `cordovarduino` has no support for writing an `ArrayBuffer` as-is...

This PR adds support for passing `ArrayBuffer` data to the `write()` method. It may not be the most efficient implementation, but I did not want to touch the native plugin code. I took the idea from https://github.com/don/BluetoothSerial/blob/master/www/bluetoothSerial.js#L47, which also provides for `Uint8Array` and and integer array arguments - however, IMHO supporting too many different data types can also lead to confusion.
