### PR TITLE
Use <lib-file> for libraries.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
         </config-file>
         <source-file src="src/android/fr/drangies/cordova/serial/Serial.java" target-dir="src/fr/drangies/cordova/serial" />
         <source-file src="src/android/fr/drangies/cordova/serial/UsbBroadcastReceiver.java" target-dir="src/fr/drangies/cordova/serial" />
-        <source-file src="lib/usbseriallibrary.jar" target-dir="libs" />
+        <lib-file src="lib/usbseriallibrary.jar" arch="device" />
     </platform>
 
     <!-- ubuntu -->


### PR DESCRIPTION
This seems necessary with cordova-android v7.1.0 due to the changed directory structure, otherwise some "weird" errors will occur with totally unrelated plugins. See, for example https://travis-ci.org/tkem/openlap/builds/374557900
