### PR TITLE
renaming plugin ID to fix the fr... package in package.json (Issue #59)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "cordovarduino",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Cordova plugin to communicate with the android USB serial port",
   "cordova": {
-    "id": "fr.drangies.cordova.serial",
+    "id": "cordovarduino",
     "platforms": [
       "android",
       "ubuntu"

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
-    id="fr.drangies.cordova.serial"
-    version="0.0.7">
+    id="cordovarduino"
+    version="0.0.9">
     <name>Serial</name>
     <description>Cordova plugin to communicate with the android USB serial port</description>
     <license>MIT</license>


### PR DESCRIPTION
I renamed the package names to cordovarduino, which is the name on npm, so this does not break npm install. I also increased the version number, feel free to skip that part.